### PR TITLE
refactor: replace POSIX semaphores with eventfd and background broker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIB_SOURCES
     src/ufifo_opts.c
     src/ufifo_sync.c
     src/ufifo_epoll.c
+    src/ufifo_broker.c
     src/ufifo_init.c
     src/ufifo_info.c
 )

--- a/inc/ufifo_internal.h
+++ b/inc/ufifo_internal.h
@@ -56,8 +56,8 @@ int __ufifo_lock_deinit(ufifo_t *handle);
 
 /* eventfd operations */
 int __ufifo_efd_create(void);
-int __ufifo_efd_wait(int efd, ufifo_t *handle);
-int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec);
+int __ufifo_efd_wait(int efd, ufifo_t *handle, int *waiters);
+int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec, int *waiters);
 int __ufifo_efd_post(int efd);
 int __ufifo_efd_drain(int efd);
 

--- a/inc/ufifo_internal.h
+++ b/inc/ufifo_internal.h
@@ -1,6 +1,5 @@
 #ifndef UFIFO_INTERNAL_H
 #define UFIFO_INTERNAL_H
-#include <limits.h>
 
 #include "kfifo.h"
 #include "ufifo.h"
@@ -17,13 +16,11 @@
 struct ufifo {
     unsigned int magic;
 
-    char name[NAME_MAX];
+    char name[128];
     unsigned int user_id;
 
     ufifo_hook_t hook;
     kfifo_t kfifo;
-    sem_t *bsem_wr;
-    sem_t *bsem_rd;
 
     int shm_fd;
     unsigned int shm_size;
@@ -33,8 +30,14 @@ struct ufifo {
     size_t ctrl_size;
     ufifo_ctrl_t *ctrl;
 
-    int rx_efd;
-    int tx_efd;
+    /* eventfd-based notification */
+    int efd_wr;       /* eventfd: write-space available (shared, one per FIFO) */
+    int efd_rd;       /* eventfd: read-data available (this user's) */
+    int *efd_rd_all;  /* array[max_users]: all readers' eventfds (for writer notify) */
+    size_t efd_count; /* max_users: size of efd_rd_all */
+
+    /* fd broker lifecycle (forked daemon, started by first open) */
+    int is_broker_owner; /* 1 if this process forked the broker daemon */
 };
 
 /* ufifo_sync.c */
@@ -50,15 +53,19 @@ int __ufifo_init_wait(int fd);
 int __ufifo_init_unlock(int fd);
 int __ufifo_lock_init(ufifo_t *handle, ufifo_lock_e type);
 int __ufifo_lock_deinit(ufifo_t *handle);
-int __ufifo_bsem_init(sem_t *bsem, unsigned int value);
-int __ufifo_bsem_deinit(sem_t *bsem);
-int __ufifo_bsem_wait(sem_t *bsem, ufifo_t *handle);
-int __ufifo_bsem_timedwait(sem_t *bsem, ufifo_t *handle, long millisec);
-int __ufifo_bsem_post(sem_t *bsem);
 
-/* ufifo_epoll.c */
-void __ufifo_efd_notify_rx(ufifo_t *handle);
-void __ufifo_efd_notify_tx(ufifo_t *handle);
+/* eventfd operations */
+int __ufifo_efd_create(void);
+int __ufifo_efd_wait(int efd, ufifo_t *handle);
+int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec);
+int __ufifo_efd_post(int efd);
+int __ufifo_efd_drain(int efd);
+
+/* ufifo_broker.c — eventfd lifecycle (fork-based broker daemon) */
+int __ufifo_acquire_eventfds(ufifo_t *handle, int is_alloc);
+int __ufifo_broker_start(ufifo_t *handle);
+int __ufifo_efd_create_all(ufifo_t *handle, unsigned int max_users);
+void __ufifo_efd_close_all(ufifo_t *handle);
 
 /* ufifo_init.c */
 void __ufifo_reap_dead_user(ufifo_t *handle, unsigned int user_id);

--- a/inc/ufifo_layout.h
+++ b/inc/ufifo_layout.h
@@ -2,19 +2,17 @@
 #define UFIFO_LAYOUT_H
 
 #include <pthread.h>
-#include <semaphore.h>
 
 #include "ufifo.h"
 
+/* Per-user control data (stored in shared memory) */
 typedef struct {
     pid_t pid;
     unsigned int active;
-
     unsigned int out;
-    sem_t bsem_rd;
-    int efd_rx_flag; /* per-user RX epoll state (IDLE/REGISTERED/PENDING) */
 } ufifo_sub_ctrl_t;
 
+/* Global FIFO control data (stored in shared memory) */
 typedef struct {
     ufifo_version_t ver;
     unsigned int init_done; /* 0 = initializing, 1 = ready (atomic) */
@@ -25,9 +23,6 @@ typedef struct {
     ufifo_lock_e lock;
     pthread_mutex_t ctrl_mutex; /* always active: protects control data */
     pthread_mutex_t data_mutex; /* governed by ufifo_lock_e: protects index movement */
-
-    sem_t bsem_wr;
-    int efd_tx_flag; /* global TX epoll state (IDLE/REGISTERED/PENDING) */
 
     ufifo_data_mode_e data_mode;
     unsigned int max_users;

--- a/inc/ufifo_layout.h
+++ b/inc/ufifo_layout.h
@@ -10,6 +10,8 @@ typedef struct {
     pid_t pid;
     unsigned int active;
     unsigned int out;
+    int rx_waiters;    /* count of threads blocked in poll() waiting for data */
+    int epoll_armed;   /* 1 = epoll listener waiting; 0 = already notified or idle */
 } ufifo_sub_ctrl_t;
 
 /* Global FIFO control data (stored in shared memory) */
@@ -23,6 +25,9 @@ typedef struct {
     ufifo_lock_e lock;
     pthread_mutex_t ctrl_mutex; /* always active: protects control data */
     pthread_mutex_t data_mutex; /* governed by ufifo_lock_e: protects index movement */
+
+    int tx_waiters;      /* count of threads blocked in poll() waiting for space */
+    int epoll_tx_armed;  /* 1 = epoll listener waiting; 0 = already notified or idle */
 
     ufifo_data_mode_e data_mode;
     unsigned int max_users;

--- a/inc/utils.h
+++ b/inc/utils.h
@@ -16,6 +16,9 @@
 
 #define smp_load_acquire(p)        __atomic_load_n((p), __ATOMIC_ACQUIRE)
 #define smp_store_release(p, v)    __atomic_store_n((p), (v), __ATOMIC_RELEASE)
+#define atomic_fetch_add(p, v)     __atomic_fetch_add((p), (v), __ATOMIC_ACQ_REL)
+#define atomic_fetch_sub(p, v)     __atomic_fetch_sub((p), (v), __ATOMIC_ACQ_REL)
+#define atomic_xchg(p, v)          __atomic_exchange_n((p), (v), __ATOMIC_ACQ_REL)
 #define READ_ONCE(p)               __atomic_load_n((p), __ATOMIC_RELAXED)
 #define WRITE_ONCE(p, v)           __atomic_store_n((p), (v), __ATOMIC_RELAXED)
 

--- a/src/ufifo_broker.c
+++ b/src/ufifo_broker.c
@@ -1,0 +1,424 @@
+#include "ufifo_internal.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* ------------------------------------------------------------------ */
+/*  Abstract namespace address                                         */
+/* ------------------------------------------------------------------ */
+
+static socklen_t __ufifo_broker_addr(const char *name, struct sockaddr_un *addr)
+{
+    memset(addr, 0, sizeof(*addr));
+    addr->sun_family = AF_UNIX;
+    addr->sun_path[0] = '\0'; /* abstract namespace */
+    int n = snprintf(addr->sun_path + 1, sizeof(addr->sun_path) - 1, "ufifo_%s_broker", name);
+    return (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + n);
+}
+
+/* ------------------------------------------------------------------ */
+/*  SCM_RIGHTS helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+static int __ufifo_send_fds(int sock, const int *fds, unsigned int nfds)
+{
+    char dummy = 'F';
+    struct iovec iov = { .iov_base = &dummy, .iov_len = 1 };
+
+    size_t cmsg_space = CMSG_SPACE(nfds * sizeof(int));
+    char *cmsg_buf = calloc(1, cmsg_space);
+    if (!cmsg_buf)
+        return -ENOMEM;
+
+    struct msghdr msg = {
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = cmsg_buf,
+        .msg_controllen = cmsg_space,
+    };
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(nfds * sizeof(int));
+    memcpy(CMSG_DATA(cmsg), fds, nfds * sizeof(int));
+
+    int ret = sendmsg(sock, &msg, 0);
+    free(cmsg_buf);
+    return ret < 0 ? -errno : 0;
+}
+
+static int __ufifo_recv_fds(int sock, int *fds, unsigned int nfds)
+{
+    char dummy;
+    struct iovec iov = { .iov_base = &dummy, .iov_len = 1 };
+
+    size_t cmsg_space = CMSG_SPACE(nfds * sizeof(int));
+    char *cmsg_buf = calloc(1, cmsg_space);
+    if (!cmsg_buf)
+        return -ENOMEM;
+
+    struct msghdr msg = {
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = cmsg_buf,
+        .msg_controllen = cmsg_space,
+    };
+
+    int ret = recvmsg(sock, &msg, 0);
+    if (ret < 0) {
+        free(cmsg_buf);
+        return -errno;
+    }
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (!cmsg || cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+        free(cmsg_buf);
+        return -EPROTO;
+    }
+
+    memcpy(fds, CMSG_DATA(cmsg), nfds * sizeof(int));
+    free(cmsg_buf);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Broker daemon loop (runs in forked child)                          */
+/*                                                                     */
+/*  Design constraints for stability:                                  */
+/*   - No mutex usage (async-signal-safe after fork)                   */
+/*   - Pre-allocate all buffers before the loop                        */
+/*   - Only syscalls: poll, accept4, sendmsg, close, shm_open         */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Broker daemon context: all data the daemon needs, copied before fork.
+ * The daemon must NOT access the parent's ufifo_t handle.
+ */
+typedef struct {
+    int listener_fd;
+    int *fds_to_send;       /* packed: [efd_wr, efd_rd_all[0..N-1]] */
+    unsigned int total_fds; /* 1 + max_users */
+    char shm_name[128];
+} broker_ctx_t;
+
+#define BROKER_POLL_INTERVAL_MS 2000
+
+static void __ufifo_broker_daemon(broker_ctx_t *ctx)
+{
+    setsid();
+
+    int null_fd = open("/dev/null", O_RDWR);
+    if (null_fd >= 0) {
+        dup2(null_fd, STDIN_FILENO);
+        dup2(null_fd, STDOUT_FILENO);
+        dup2(null_fd, STDERR_FILENO);
+        if (null_fd > STDERR_FILENO)
+            close(null_fd);
+    }
+
+    while (1) {
+        struct pollfd pfd = { .fd = ctx->listener_fd, .events = POLLIN };
+        int ready = poll(&pfd, 1, BROKER_POLL_INTERVAL_MS);
+
+        if (ready > 0 && (pfd.revents & POLLIN)) {
+            int client = accept4(ctx->listener_fd, NULL, NULL, SOCK_CLOEXEC);
+            if (client >= 0) {
+                /* Ignore send errors: client may have disconnected */
+                __ufifo_send_fds(client, ctx->fds_to_send, ctx->total_fds);
+                close(client);
+            }
+        }
+
+        /* Periodic liveness check: exit when shm is destroyed */
+        int probe = shm_open(ctx->shm_name, O_RDONLY, 0);
+        if (probe < 0) {
+            if (errno == ENOENT)
+                break; /* shm destroyed → graceful exit */
+            /* Other errors (e.g. permission): stay alive, be conservative */
+        } else {
+            close(probe);
+        }
+    }
+
+    /* Cleanup: close listener + all eventfds */
+    close(ctx->listener_fd);
+    unsigned int i;
+    for (i = 0; i < ctx->total_fds; i++)
+        close(ctx->fds_to_send[i]);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Broker start (double-fork)                                         */
+/* ------------------------------------------------------------------ */
+
+static int __ufifo_broker_fork(ufifo_t *handle, int listener_fd)
+{
+    unsigned int total_fds = 1 + handle->efd_count;
+
+    /* Pre-pack fd array on parent's stack; child inherits a copy */
+    int *fds_to_send = malloc(total_fds * sizeof(int));
+    if (!fds_to_send)
+        return -ENOMEM;
+
+    fds_to_send[0] = handle->efd_wr;
+    memcpy(fds_to_send + 1, handle->efd_rd_all, handle->efd_count * sizeof(int));
+
+    broker_ctx_t ctx = {
+        .listener_fd = listener_fd,
+        .fds_to_send = fds_to_send,
+        .total_fds = total_fds,
+    };
+    strncpy(ctx.shm_name, handle->name, sizeof(ctx.shm_name) - 1);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        int err = errno;
+        free(fds_to_send);
+        return -err;
+    }
+
+    if (pid == 0) {
+        /* First child: double-fork to orphan the daemon */
+        pid_t pid2 = fork();
+        if (pid2 > 0)
+            _exit(0); /* first child exits immediately */
+        if (pid2 < 0)
+            _exit(1);
+
+        /* Grandchild: actual broker daemon */
+
+        /* Close fds the broker doesn't need */
+        close(handle->shm_fd);
+        close(handle->ctrl_fd);
+        /* Note: shm_mem/ctrl are mmap'd, child has COW copies — harmless */
+
+        __ufifo_broker_daemon(&ctx);
+        /* ctx.fds_to_send is freed implicitly by _exit */
+        _exit(0);
+    }
+
+    /* Parent: wait for first child (returns almost immediately) */
+    waitpid(pid, NULL, 0);
+
+    /* Parent no longer needs the listener (broker owns it) */
+    close(listener_fd);
+    free(fds_to_send);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Broker start: create listener + fork                               */
+/* ------------------------------------------------------------------ */
+
+int __ufifo_broker_start(ufifo_t *handle)
+{
+    struct sockaddr_un addr;
+    socklen_t addr_len;
+    int listener_fd;
+    int ret;
+
+    listener_fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+    if (listener_fd < 0)
+        return -errno;
+
+    addr_len = __ufifo_broker_addr(handle->name, &addr);
+
+    /*
+     * bind() to abstract namespace is atomic: only one process can bind
+     * to the same address. This serves as the "broker election" lock.
+     */
+    if (bind(listener_fd, (struct sockaddr *)&addr, addr_len) < 0) {
+        int err = errno;
+        close(listener_fd);
+        return -err; /* EADDRINUSE = someone else won */
+    }
+
+    if (listen(listener_fd, 8) < 0) {
+        int err = errno;
+        close(listener_fd);
+        return -err;
+    }
+
+    ret = __ufifo_broker_fork(handle, listener_fd);
+    if (ret < 0) {
+        close(listener_fd);
+        return ret;
+    }
+
+    handle->is_broker_owner = 1;
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Broker connect: ATTACH process receives eventfds                   */
+/* ------------------------------------------------------------------ */
+
+static int __ufifo_broker_connect(ufifo_t *handle)
+{
+    struct sockaddr_un addr;
+    socklen_t addr_len;
+    unsigned int total_fds = 1 + handle->ctrl->max_users;
+    int ret;
+
+    int sock = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (sock < 0)
+        return -errno;
+
+    addr_len = __ufifo_broker_addr(handle->name, &addr);
+
+    /* Retry with brief backoff (broker may be starting up) */
+    int attempts = 50;
+    while (attempts-- > 0) {
+        ret = connect(sock, (struct sockaddr *)&addr, addr_len);
+        if (ret == 0)
+            break;
+        if (errno != ECONNREFUSED && errno != ENOENT) {
+            close(sock);
+            return -errno;
+        }
+        usleep(10000); /* 10ms */
+    }
+    if (ret < 0) {
+        close(sock);
+        return -ETIMEDOUT;
+    }
+
+    int *fds = calloc(total_fds, sizeof(int));
+    if (!fds) {
+        close(sock);
+        return -ENOMEM;
+    }
+
+    ret = __ufifo_recv_fds(sock, fds, total_fds);
+    close(sock);
+
+    if (ret < 0) {
+        free(fds);
+        return ret;
+    }
+
+    /* Unpack: [efd_wr, efd_rd_all[0], efd_rd_all[1], ...] */
+    handle->efd_wr = fds[0];
+    handle->efd_count = handle->ctrl->max_users;
+    handle->efd_rd_all = malloc(handle->efd_count * sizeof(int));
+    if (!handle->efd_rd_all) {
+        unsigned int i;
+        for (i = 0; i < total_fds; i++)
+            close(fds[i]);
+        free(fds);
+        return -ENOMEM;
+    }
+    memcpy(handle->efd_rd_all, fds + 1, handle->efd_count * sizeof(int));
+    free(fds);
+
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Unified eventfd acquisition (used by both ALLOC and ATTACH)        */
+/* ------------------------------------------------------------------ */
+
+int __ufifo_acquire_eventfds(ufifo_t *handle, int is_alloc)
+{
+    int ret;
+
+    /* Step 1: try connecting to an existing broker (ATTACH only) */
+    if (!is_alloc) {
+        ret = __ufifo_broker_connect(handle);
+        if (ret == 0)
+            goto set_rd;
+    }
+
+    /* Step 2: no broker → bootstrap: create eventfds + fork broker */
+    ret = __ufifo_efd_create_all(handle, handle->ctrl->max_users);
+    if (ret < 0)
+        return ret;
+
+    ret = __ufifo_broker_start(handle);
+    if (ret == -EADDRINUSE) {
+        /*
+         * Another process won the broker election race.
+         * Discard our eventfds and connect to the winner's broker.
+         */
+        __ufifo_efd_close_all(handle);
+        ret = __ufifo_broker_connect(handle);
+        if (ret < 0)
+            return ret;
+    } else if (ret < 0) {
+        __ufifo_efd_close_all(handle);
+        return ret;
+    }
+
+set_rd:
+    handle->efd_rd = __ufifo_is_shared(handle) ? handle->efd_rd_all[handle->user_id] : handle->efd_rd_all[0];
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  eventfd creation and cleanup                                       */
+/* ------------------------------------------------------------------ */
+
+int __ufifo_efd_create_all(ufifo_t *handle, unsigned int max_users)
+{
+    unsigned int i;
+
+    handle->efd_wr = __ufifo_efd_create();
+    if (handle->efd_wr < 0)
+        return -errno;
+
+    handle->efd_count = max_users;
+    handle->efd_rd_all = calloc(max_users, sizeof(int));
+    if (!handle->efd_rd_all) {
+        close(handle->efd_wr);
+        handle->efd_wr = -1;
+        return -ENOMEM;
+    }
+
+    for (i = 0; i < max_users; i++) {
+        handle->efd_rd_all[i] = __ufifo_efd_create();
+        if (handle->efd_rd_all[i] < 0) {
+            int err = errno;
+            unsigned int j;
+            for (j = 0; j < i; j++)
+                close(handle->efd_rd_all[j]);
+            free(handle->efd_rd_all);
+            handle->efd_rd_all = NULL;
+            close(handle->efd_wr);
+            handle->efd_wr = -1;
+            return -err;
+        }
+    }
+
+    return 0;
+}
+
+void __ufifo_efd_close_all(ufifo_t *handle)
+{
+    if (handle->efd_wr >= 0) {
+        close(handle->efd_wr);
+        handle->efd_wr = -1;
+    }
+
+    if (handle->efd_rd_all) {
+        unsigned int i;
+        for (i = 0; i < handle->efd_count; i++) {
+            if (handle->efd_rd_all[i] >= 0)
+                close(handle->efd_rd_all[i]);
+        }
+        free(handle->efd_rd_all);
+        handle->efd_rd_all = NULL;
+    }
+    handle->efd_rd = -1;
+}

--- a/src/ufifo_epoll.c
+++ b/src/ufifo_epoll.c
@@ -1,15 +1,42 @@
 #include "ufifo_internal.h"
 #include <errno.h>
 
+#include "utils.h"
+
 int ufifo_get_rx_fd(ufifo_t *handle)
 {
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
+    unsigned int idx = __ufifo_is_shared(handle) ? handle->user_id : 0;
+
+    __ufifo_ctrl_lock(handle);
+
+    /* Arm the notification. If data is already available, fire immediately. */
+    if (READ_ONCE(handle->kfifo.in) != READ_ONCE(handle->kfifo.out)) {
+        __ufifo_efd_post(handle->efd_rd);
+        /* Leave epoll_armed = 0: producer will re-arm on next drain cycle */
+    } else {
+        smp_store_release(&handle->ctrl->users[idx].epoll_armed, 1);
+    }
+
+    __ufifo_ctrl_unlock(handle);
     return handle->efd_rd;
 }
 
 int ufifo_get_tx_fd(ufifo_t *handle)
 {
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
+
+    __ufifo_ctrl_lock(handle);
+
+    unsigned int len = READ_ONCE(handle->kfifo.in) - READ_ONCE(handle->kfifo.out);
+    unsigned int unused = *handle->kfifo.mask + 1 - len;
+    if (unused > 0) {
+        __ufifo_efd_post(handle->efd_wr);
+    } else {
+        smp_store_release(&handle->ctrl->epoll_tx_armed, 1);
+    }
+
+    __ufifo_ctrl_unlock(handle);
     return handle->efd_wr;
 }
 
@@ -18,7 +45,10 @@ int ufifo_drain_rx_fd(ufifo_t *handle)
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
     if (handle->efd_rd < 0)
         return -EINVAL;
-    return __ufifo_efd_drain(handle->efd_rd);
+    unsigned int idx = __ufifo_is_shared(handle) ? handle->user_id : 0;
+    int ret = __ufifo_efd_drain(handle->efd_rd);
+    smp_store_release(&handle->ctrl->users[idx].epoll_armed, 1); /* re-arm */
+    return ret;
 }
 
 int ufifo_drain_tx_fd(ufifo_t *handle)
@@ -26,5 +56,7 @@ int ufifo_drain_tx_fd(ufifo_t *handle)
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
     if (handle->efd_wr < 0)
         return -EINVAL;
-    return __ufifo_efd_drain(handle->efd_wr);
+    int ret = __ufifo_efd_drain(handle->efd_wr);
+    smp_store_release(&handle->ctrl->epoll_tx_armed, 1); /* re-arm */
+    return ret;
 }

--- a/src/ufifo_epoll.c
+++ b/src/ufifo_epoll.c
@@ -1,187 +1,30 @@
 #include "ufifo_internal.h"
 #include <errno.h>
-#include <pthread.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-
-#include "utils.h"
-
-/* epoll notification state machine: IDLE → REGISTERED → PENDING → REGISTERED */
-enum {
-    UFIFO_EFD_IDLE = 0,       /* no epoll fd registered */
-    UFIFO_EFD_REGISTERED = 1, /* epoll fd registered, no pending notification */
-    UFIFO_EFD_PENDING = 2,    /* epoll fd registered, notification sent but not yet drained */
-};
-
-/* Process-global sender socket for UDS notifications (lazy init) */
-static int __ufifo_sender_fd = -1;
-static pthread_once_t __ufifo_sender_once = PTHREAD_ONCE_INIT;
-
-static void __ufifo_sender_init(void)
-{
-    __ufifo_sender_fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-}
-
-static int __ufifo_get_sender_fd(void)
-{
-    pthread_once(&__ufifo_sender_once, __ufifo_sender_init);
-    return __ufifo_sender_fd;
-}
-
-static socklen_t __ufifo_notify_addr(const char *name, unsigned int user_id, struct sockaddr_un *addr, int is_rx)
-{
-    const char *fmt = "ufifo_%s_%s_%u";
-
-    memset(addr, 0, sizeof(*addr));
-    addr->sun_family = AF_UNIX;
-    addr->sun_path[0] = '\0';
-    int n = snprintf(addr->sun_path + 1, sizeof(addr->sun_path) - 1, fmt, is_rx ? "rx" : "tx", name, user_id);
-    return (socklen_t)(offsetof(struct sockaddr_un, sun_path) + 1 + n);
-}
-
-void __ufifo_efd_notify_rx(ufifo_t *handle)
-{
-    int sfd = __ufifo_get_sender_fd();
-    if (sfd < 0)
-        return;
-
-    unsigned int i;
-    struct sockaddr_un addr;
-    for (i = 0; i < handle->ctrl->max_users; i++) {
-        if (!READ_ONCE(&handle->ctrl->users[i].active))
-            continue;
-
-        unsigned int state = smp_load_acquire(&handle->ctrl->users[i].efd_rx_flag);
-        if (state != UFIFO_EFD_REGISTERED)
-            continue; /* IDLE → skip; PENDING → coalesce */
-
-        smp_store_release(&handle->ctrl->users[i].efd_rx_flag, UFIFO_EFD_PENDING);
-        socklen_t len = __ufifo_notify_addr(handle->name, i, &addr, 1);
-        sendto(sfd, "1", 1, MSG_DONTWAIT, (struct sockaddr *)&addr, len);
-    }
-}
-
-void __ufifo_efd_notify_tx(ufifo_t *handle)
-{
-    int state = smp_load_acquire(&handle->ctrl->efd_tx_flag);
-    if (state != UFIFO_EFD_REGISTERED)
-        return; /* IDLE → no one registered; PENDING → coalesce */
-
-    smp_store_release(&handle->ctrl->efd_tx_flag, UFIFO_EFD_PENDING);
-
-    int sfd = __ufifo_get_sender_fd();
-    if (sfd < 0)
-        return;
-
-    unsigned int i;
-    struct sockaddr_un addr;
-    for (i = 0; i < handle->ctrl->max_users; i++) {
-        if (!READ_ONCE(&handle->ctrl->users[i].active))
-            continue;
-        socklen_t len = __ufifo_notify_addr(handle->name, i, &addr, 0);
-        sendto(sfd, "1", 1, MSG_DONTWAIT, (struct sockaddr *)&addr, len);
-    }
-}
-
-static int __ufifo_get_efd(ufifo_t *handle, int is_rx)
-{
-    int ret_fd;
-    __ufifo_ctrl_lock(handle);
-
-    int *efd = is_rx ? &handle->rx_efd : &handle->tx_efd;
-    int *efd_flags;
-    struct sockaddr_un addr;
-    socklen_t addr_len;
-
-    if (*efd >= 0) {
-        ret_fd = *efd;
-        goto end;
-    }
-
-    *efd = socket(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-    if (*efd < 0) {
-        ret_fd = -1;
-        goto end;
-    }
-
-    addr_len = __ufifo_notify_addr(handle->name, handle->user_id, &addr, is_rx);
-    if (bind(*efd, (struct sockaddr *)&addr, addr_len) < 0) {
-        close(*efd);
-        *efd = -1;
-        ret_fd = -1;
-        goto end;
-    }
-
-    /* Mark this user as epoll-registered in shared memory */
-    efd_flags = is_rx ? &handle->ctrl->users[handle->user_id].efd_rx_flag : &handle->ctrl->efd_tx_flag;
-    smp_store_release(efd_flags, UFIFO_EFD_REGISTERED);
-
-    /* Pre-arm condition: check if we should send a notification to self */
-    int should_arm = 0;
-    if (is_rx) {
-        if (READ_ONCE(handle->kfifo.in) != READ_ONCE(handle->kfifo.out))
-            should_arm = 1;
-    } else {
-        unsigned int len = READ_ONCE(handle->kfifo.in) - READ_ONCE(handle->kfifo.out);
-        unsigned int unused = *handle->kfifo.mask + 1 - len;
-        if (unused > 0)
-            should_arm = 1;
-    }
-
-    if (should_arm) {
-        int sfd = __ufifo_get_sender_fd();
-        if (sfd >= 0) {
-            sendto(sfd, "1", 1, MSG_DONTWAIT, (struct sockaddr *)&addr, addr_len);
-            /* Pre-arm also sets pending since we just sent a notification */
-            smp_store_release(efd_flags, UFIFO_EFD_PENDING);
-        }
-    }
-
-    ret_fd = *efd;
-
-end:
-    __ufifo_ctrl_unlock(handle);
-    return ret_fd;
-}
 
 int ufifo_get_rx_fd(ufifo_t *handle)
 {
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
-    return __ufifo_get_efd(handle, 1);
+    return handle->efd_rd;
 }
 
 int ufifo_get_tx_fd(ufifo_t *handle)
 {
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
-    return __ufifo_get_efd(handle, 0);
-}
-
-static int __ufifo_drain_efd(int fd, int *efd_flags)
-{
-    if (fd < 0)
-        return -EINVAL;
-
-    char buf[128];
-    while (recv(fd, buf, sizeof(buf), MSG_DONTWAIT) > 0) {
-    }
-
-    /* Transition: PENDING → REGISTERED (re-arm for next notification) */
-    smp_store_release(efd_flags, UFIFO_EFD_REGISTERED);
-    return 0;
+    return handle->efd_wr;
 }
 
 int ufifo_drain_rx_fd(ufifo_t *handle)
 {
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
-    return __ufifo_drain_efd(handle->rx_efd, &handle->ctrl->users[handle->user_id].efd_rx_flag);
+    if (handle->efd_rd < 0)
+        return -EINVAL;
+    return __ufifo_efd_drain(handle->efd_rd);
 }
 
 int ufifo_drain_tx_fd(ufifo_t *handle)
 {
     UFIFO_CHECK_HANDLE(handle, -EINVAL);
-    return __ufifo_drain_efd(handle->tx_efd, &handle->ctrl->efd_tx_flag);
+    if (handle->efd_wr < 0)
+        return -EINVAL;
+    return __ufifo_efd_drain(handle->efd_wr);
 }

--- a/src/ufifo_info.c
+++ b/src/ufifo_info.c
@@ -69,8 +69,10 @@ void ufifo_dump(ufifo_t *handle)
 
     __ufifo_log("Pointers: in = %u (offset: %u), out = %u (offset: %u)\n", in, in & mask, out, out & mask);
 
-    // fd epoll info
-    __ufifo_log("Rx Efd: %d, Tx Efd: %d\n", handle->rx_efd, handle->tx_efd);
+    /* eventfd info */
+    __ufifo_log("Efd Wr: %d, Efd Rd: %d, Broker Owner: %s\n",
+                handle->efd_wr, handle->efd_rd,
+                handle->is_broker_owner ? "yes" : "no");
 
     unsigned int i;
     for (i = 0; i < handle->ctrl->max_users; i++) {

--- a/src/ufifo_init.c
+++ b/src/ufifo_init.c
@@ -2,7 +2,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,6 +12,10 @@
 
 #include "log2.h"
 #include "utils.h"
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
 
 int __ufifo_is_shared(ufifo_t *handle)
 {
@@ -26,13 +29,14 @@ void __ufifo_reap_dead_user(ufifo_t *handle, unsigned int user_id)
     if (READ_ONCE(&ctrl->users[user_id].active)) {
         WRITE_ONCE(&ctrl->users[user_id].active, 0);
         ctrl->num_users--;
-
-        while (sem_trywait(&ctrl->users[user_id].bsem_rd) == 0) {
-        }
     }
 }
 
-int __ufifo_register(ufifo_t *handle)
+/* ------------------------------------------------------------------ */
+/*  User registration                                                  */
+/* ------------------------------------------------------------------ */
+
+static int __ufifo_register(ufifo_t *handle)
 {
     ufifo_ctrl_t *ctrl = handle->ctrl;
     unsigned int i;
@@ -76,6 +80,10 @@ static void __ufifo_unregister(ufifo_t *handle)
     }
 }
 
+/* ------------------------------------------------------------------ */
+/*  Hook + version                                                     */
+/* ------------------------------------------------------------------ */
+
 static int __ufifo_hook_init(ufifo_t *handle, ufifo_hook_t *hook)
 {
     handle->hook.recsize = hook->recsize;
@@ -103,11 +111,15 @@ static int __ufifo_version_check(ufifo_ctrl_t *ctrl)
     return 0;
 }
 
+/* ------------------------------------------------------------------ */
+/*  ATTACH path                                                        */
+/* ------------------------------------------------------------------ */
+
 static int __ufifo_init_from_shm(ufifo_t *handle)
 {
     int ret = 0;
     struct stat st;
-    char ctrl_name[NAME_MAX + 8];
+    char ctrl_name[128 + 8];
 
     snprintf(ctrl_name, sizeof(ctrl_name), "%s_ctrl", handle->name);
     handle->ctrl_fd = shm_open(ctrl_name, O_RDWR, (S_IRUSR | S_IWUSR));
@@ -159,18 +171,24 @@ static int __ufifo_init_from_shm(ufifo_t *handle)
     handle->user_id = (unsigned int)ret;
     handle->kfifo.in = &handle->ctrl->in;
     handle->kfifo.mask = &handle->ctrl->mask;
-    handle->bsem_wr = &handle->ctrl->bsem_wr;
     if (__ufifo_is_shared(handle)) {
         WRITE_ONCE(&handle->ctrl->users[handle->user_id].out, READ_ONCE(&handle->ctrl->in));
         handle->kfifo.out = &handle->ctrl->users[handle->user_id].out;
-        handle->bsem_rd = &handle->ctrl->users[handle->user_id].bsem_rd;
     } else {
         handle->kfifo.out = &handle->ctrl->users[0].out;
-        handle->bsem_rd = &handle->ctrl->users[0].bsem_rd;
     }
+
+    /* Acquire eventfds via broker (connect or bootstrap) */
+    ret = __ufifo_acquire_eventfds(handle, 0);
+    if (ret < 0)
+        goto err_unregister;
 
     return 0;
 
+err_unregister:
+    __ufifo_ctrl_lock(handle);
+    __ufifo_unregister(handle);
+    __ufifo_ctrl_unlock(handle);
 err_data_mmap:
     munmap(handle->shm_mem, handle->shm_size);
 err_ctrl_mmap:
@@ -181,11 +199,15 @@ end:
     return ret;
 }
 
+/* ------------------------------------------------------------------ */
+/*  ALLOC path                                                         */
+/* ------------------------------------------------------------------ */
+
 static int __ufifo_init_from_user(ufifo_t *handle, ufifo_alloc_t *alloc)
 {
     int ret = 0;
     unsigned int i;
-    char ctrl_name[NAME_MAX + 8];
+    char ctrl_name[128 + 8];
 
     if (!alloc->size)
         return -EINVAL;
@@ -221,7 +243,6 @@ static int __ufifo_init_from_user(ufifo_t *handle, ufifo_alloc_t *alloc)
     handle->ctrl->num_users = 0;
     for (i = 0; i < alloc->max_users; i++) {
         handle->ctrl->users[i].active = 0;
-        __ufifo_bsem_init(&handle->ctrl->users[i].bsem_rd, 0);
     }
 
     handle->shm_size = roundup_pow_of_two(alloc->size);
@@ -250,9 +271,11 @@ static int __ufifo_init_from_user(ufifo_t *handle, ufifo_alloc_t *alloc)
     ret = kfifo_init(&handle->kfifo, handle->shm_size);
     if (ret < 0)
         goto err_register;
-    handle->bsem_wr = &handle->ctrl->bsem_wr;
-    __ufifo_bsem_init(handle->bsem_wr, 0);
-    handle->bsem_rd = &handle->ctrl->users[handle->user_id].bsem_rd;
+
+    /* Acquire eventfds via broker (create + fork broker) */
+    ret = __ufifo_acquire_eventfds(handle, 1);
+    if (ret < 0)
+        goto err_register;
 
     ufifo_get_version_info(NULL, &handle->ctrl->ver);
     smp_store_release(&handle->ctrl->init_done, 1);
@@ -276,6 +299,10 @@ end:
     return ret;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Validation                                                         */
+/* ------------------------------------------------------------------ */
+
 static int __ufifo_init_validate(const ufifo_init_t *init)
 {
     if (init->opt >= UFIFO_OPT_MAX) {
@@ -297,6 +324,10 @@ static int __ufifo_init_validate(const ufifo_init_t *init)
     return 0;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Public API: open / close / destroy                                 */
+/* ------------------------------------------------------------------ */
+
 int ufifo_open(const char *name, const ufifo_init_t *init, ufifo_t **handle)
 {
     int ret = 0;
@@ -315,8 +346,8 @@ int ufifo_open(const char *name, const ufifo_init_t *init, ufifo_t **handle)
     fifo = calloc(1, sizeof(ufifo_t));
     if (fifo == NULL)
         return -ENOMEM;
-    fifo->rx_efd = -1;
-    fifo->tx_efd = -1;
+    fifo->efd_wr = -1;
+    fifo->efd_rd = -1;
 
     strncpy(fifo->name, name, sizeof(fifo->name) - 1);
     ret = __ufifo_hook_init(fifo, &fifo_init.hook);
@@ -325,7 +356,15 @@ int ufifo_open(const char *name, const ufifo_init_t *init, ufifo_t **handle)
 
     if (fifo_init.opt == UFIFO_OPT_ALLOC) {
         if (fifo_init.alloc.force) {
-            fifo->shm_fd = shm_open(name, O_RDWR | O_CREAT, (S_IRUSR | S_IWUSR));
+            /*
+             * force=1: nuke old shm to trigger old broker exit,
+             * then recreate. This is a cold-restart operation.
+             */
+            char ctrl_name[128 + 8];
+            snprintf(ctrl_name, sizeof(ctrl_name), "%s_ctrl", name);
+            shm_unlink(name);
+            shm_unlink(ctrl_name);
+            fifo->shm_fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, (S_IRUSR | S_IWUSR));
         } else {
             fifo->shm_fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, (S_IRUSR | S_IWUSR));
             if (fifo->shm_fd < 0 && errno == EEXIST) {
@@ -377,29 +416,18 @@ err1:
 
 static int __ufifo_close(ufifo_t *handle, int destroy)
 {
-    char ctrl_name[NAME_MAX + 8];
+    char ctrl_name[128 + 8];
 
-    if (handle->rx_efd >= 0) {
-        smp_store_release(&handle->ctrl->users[handle->user_id].efd_rx_flag, 0);
-        close(handle->rx_efd);
-        handle->rx_efd = -1;
-    }
-    if (handle->tx_efd >= 0) {
-        smp_store_release(&handle->ctrl->efd_tx_flag, 0);
-        close(handle->tx_efd);
-        handle->tx_efd = -1;
-    }
     __ufifo_ctrl_lock(handle);
     __ufifo_unregister(handle);
     __ufifo_ctrl_unlock(handle);
+
     if (destroy) {
-        unsigned int i;
         __ufifo_lock_deinit(handle);
-        __ufifo_bsem_deinit(handle->bsem_wr);
-        for (i = 0; i < handle->ctrl->max_users; i++) {
-            __ufifo_bsem_deinit(&handle->ctrl->users[i].bsem_rd);
-        }
     }
+
+    /* Close this process's eventfds */
+    __ufifo_efd_close_all(handle);
 
     munmap(handle->shm_mem, handle->shm_size);
     close(handle->shm_fd);
@@ -408,6 +436,7 @@ static int __ufifo_close(ufifo_t *handle, int destroy)
     close(handle->ctrl_fd);
 
     if (destroy) {
+        /* Unlink shm → broker daemon detects and exits */
         shm_unlink(handle->name);
         snprintf(ctrl_name, sizeof(ctrl_name), "%s_ctrl", handle->name);
         shm_unlink(ctrl_name);

--- a/src/ufifo_opts.c
+++ b/src/ufifo_opts.c
@@ -155,9 +155,9 @@ static unsigned int __ufifo_put(ufifo_t *handle, void *buf, unsigned int size, l
             if (millisec == 0) {
                 ret = -1;
             } else if (millisec == -1) {
-                ret = __ufifo_bsem_wait(handle->bsem_wr, handle);
+                ret = __ufifo_efd_wait(handle->efd_wr, handle);
             } else {
-                ret = __ufifo_bsem_timedwait(handle->bsem_wr, handle, millisec);
+                ret = __ufifo_efd_timedwait(handle->efd_wr, handle, millisec);
                 millisec = 0;
             }
             if (ret) {
@@ -185,13 +185,12 @@ static unsigned int __ufifo_put(ufifo_t *handle, void *buf, unsigned int size, l
         unsigned int i;
         for (i = 0; i < handle->ctrl->max_users; i++) {
             if (READ_ONCE(&handle->ctrl->users[i].active)) {
-                __ufifo_bsem_post(&handle->ctrl->users[i].bsem_rd);
+                __ufifo_efd_post(handle->efd_rd_all[i]);
             }
         }
     } else {
-        __ufifo_bsem_post(handle->bsem_rd);
+        __ufifo_efd_post(handle->efd_rd_all[0]);
     }
-    __ufifo_efd_notify_rx(handle);
 
 end:
     __ufifo_data_unlock(handle);
@@ -229,9 +228,9 @@ static unsigned int __ufifo_get(ufifo_t *handle, void *buf, unsigned int size, l
             if (millisec == 0) {
                 ret = -1;
             } else if (millisec == -1) {
-                ret = __ufifo_bsem_wait(handle->bsem_rd, handle);
+                ret = __ufifo_efd_wait(handle->efd_rd, handle);
             } else {
-                ret = __ufifo_bsem_timedwait(handle->bsem_rd, handle, millisec);
+                ret = __ufifo_efd_timedwait(handle->efd_rd, handle, millisec);
                 millisec = 0;
             }
             if (ret) {
@@ -252,8 +251,7 @@ static unsigned int __ufifo_get(ufifo_t *handle, void *buf, unsigned int size, l
         len = kfifo_out(&handle->kfifo, handle->shm_mem, buf, size);
     }
 
-    __ufifo_bsem_post(handle->bsem_wr);
-    __ufifo_efd_notify_tx(handle);
+    __ufifo_efd_post(handle->efd_wr);
 
 end:
     __ufifo_data_unlock(handle);
@@ -291,9 +289,9 @@ static unsigned int __ufifo_peek(ufifo_t *handle, void *buf, unsigned int size, 
             if (millisec == 0) {
                 ret = -1;
             } else if (millisec == -1) {
-                ret = __ufifo_bsem_wait(handle->bsem_rd, handle);
+                ret = __ufifo_efd_wait(handle->efd_rd, handle);
             } else {
-                ret = __ufifo_bsem_timedwait(handle->bsem_rd, handle, millisec);
+                ret = __ufifo_efd_timedwait(handle->efd_rd, handle, millisec);
                 millisec = 0;
             }
             if (ret) {
@@ -313,7 +311,7 @@ static unsigned int __ufifo_peek(ufifo_t *handle, void *buf, unsigned int size, 
         len = kfifo_out_peek(&handle->kfifo, handle->shm_mem, buf, size);
     }
 
-    __ufifo_bsem_post(handle->bsem_wr);
+    __ufifo_efd_post(handle->efd_wr);
 end:
     __ufifo_data_unlock(handle);
 

--- a/src/ufifo_opts.c
+++ b/src/ufifo_opts.c
@@ -3,6 +3,21 @@
 
 #include "utils.h"
 
+/*
+ * Unified notification: post to eventfd only when someone is listening.
+ * - rx_waiters > 0: a thread is blocked in poll(), always post.
+ * - epoll_armed == 1: an epoll listener is registered.
+ *   Use atomic_exchange to flip 1→0 so only ONE producer posts per arm cycle.
+ */
+static inline void __ufifo_notify_efd(int efd, int *waiters, int *epoll_armed)
+{
+    if (smp_load_acquire(waiters) > 0) {
+        __ufifo_efd_post(efd);
+    } else if (atomic_xchg(epoll_armed, 0)) {
+        __ufifo_efd_post(efd);
+    }
+}
+
 static unsigned int __ufifo_min_out(ufifo_t *handle)
 {
     unsigned int in_val = READ_ONCE(handle->kfifo.in);
@@ -155,9 +170,9 @@ static unsigned int __ufifo_put(ufifo_t *handle, void *buf, unsigned int size, l
             if (millisec == 0) {
                 ret = -1;
             } else if (millisec == -1) {
-                ret = __ufifo_efd_wait(handle->efd_wr, handle);
+                ret = __ufifo_efd_wait(handle->efd_wr, handle, &handle->ctrl->tx_waiters);
             } else {
-                ret = __ufifo_efd_timedwait(handle->efd_wr, handle, millisec);
+                ret = __ufifo_efd_timedwait(handle->efd_wr, handle, millisec, &handle->ctrl->tx_waiters);
                 millisec = 0;
             }
             if (ret) {
@@ -184,12 +199,15 @@ static unsigned int __ufifo_put(ufifo_t *handle, void *buf, unsigned int size, l
     if (__ufifo_is_shared(handle)) {
         unsigned int i;
         for (i = 0; i < handle->ctrl->max_users; i++) {
-            if (READ_ONCE(&handle->ctrl->users[i].active)) {
-                __ufifo_efd_post(handle->efd_rd_all[i]);
-            }
+            if (READ_ONCE(&handle->ctrl->users[i].active))
+                __ufifo_notify_efd(handle->efd_rd_all[i],
+                                   &handle->ctrl->users[i].rx_waiters,
+                                   &handle->ctrl->users[i].epoll_armed);
         }
     } else {
-        __ufifo_efd_post(handle->efd_rd_all[0]);
+        __ufifo_notify_efd(handle->efd_rd_all[0],
+                           &handle->ctrl->users[0].rx_waiters,
+                           &handle->ctrl->users[0].epoll_armed);
     }
 
 end:
@@ -228,9 +246,9 @@ static unsigned int __ufifo_get(ufifo_t *handle, void *buf, unsigned int size, l
             if (millisec == 0) {
                 ret = -1;
             } else if (millisec == -1) {
-                ret = __ufifo_efd_wait(handle->efd_rd, handle);
+                ret = __ufifo_efd_wait(handle->efd_rd, handle, &handle->ctrl->users[__ufifo_is_shared(handle) ? handle->user_id : 0].rx_waiters);
             } else {
-                ret = __ufifo_efd_timedwait(handle->efd_rd, handle, millisec);
+                ret = __ufifo_efd_timedwait(handle->efd_rd, handle, millisec, &handle->ctrl->users[__ufifo_is_shared(handle) ? handle->user_id : 0].rx_waiters);
                 millisec = 0;
             }
             if (ret) {
@@ -251,7 +269,9 @@ static unsigned int __ufifo_get(ufifo_t *handle, void *buf, unsigned int size, l
         len = kfifo_out(&handle->kfifo, handle->shm_mem, buf, size);
     }
 
-    __ufifo_efd_post(handle->efd_wr);
+    __ufifo_notify_efd(handle->efd_wr,
+                       &handle->ctrl->tx_waiters,
+                       &handle->ctrl->epoll_tx_armed);
 
 end:
     __ufifo_data_unlock(handle);
@@ -289,9 +309,9 @@ static unsigned int __ufifo_peek(ufifo_t *handle, void *buf, unsigned int size, 
             if (millisec == 0) {
                 ret = -1;
             } else if (millisec == -1) {
-                ret = __ufifo_efd_wait(handle->efd_rd, handle);
+                ret = __ufifo_efd_wait(handle->efd_rd, handle, &handle->ctrl->users[__ufifo_is_shared(handle) ? handle->user_id : 0].rx_waiters);
             } else {
-                ret = __ufifo_efd_timedwait(handle->efd_rd, handle, millisec);
+                ret = __ufifo_efd_timedwait(handle->efd_rd, handle, millisec, &handle->ctrl->users[__ufifo_is_shared(handle) ? handle->user_id : 0].rx_waiters);
                 millisec = 0;
             }
             if (ret) {
@@ -311,7 +331,9 @@ static unsigned int __ufifo_peek(ufifo_t *handle, void *buf, unsigned int size, 
         len = kfifo_out_peek(&handle->kfifo, handle->shm_mem, buf, size);
     }
 
-    __ufifo_efd_post(handle->efd_wr);
+    __ufifo_notify_efd(handle->efd_wr,
+                       &handle->ctrl->tx_waiters,
+                       &handle->ctrl->epoll_tx_armed);
 end:
     __ufifo_data_unlock(handle);
 

--- a/src/ufifo_sync.c
+++ b/src/ufifo_sync.c
@@ -1,8 +1,12 @@
 #include "ufifo_internal.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <pthread.h>
-#include <time.h>
+#include <stdint.h>
+#include <sys/eventfd.h>
+
+#include <unistd.h>
 
 int __ufifo_ctrl_lock(ufifo_t *handle)
 {
@@ -114,59 +118,69 @@ int __ufifo_lock_deinit(ufifo_t *handle)
     return ret;
 }
 
-int __ufifo_bsem_init(sem_t *bsem, unsigned int value)
+int __ufifo_efd_create(void)
 {
-    return sem_init(bsem, 1, value);
+    return eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK | EFD_CLOEXEC);
 }
 
-int __ufifo_bsem_deinit(sem_t *bsem)
+int __ufifo_efd_wait(int efd, ufifo_t *handle)
 {
-    return sem_destroy(bsem);
-}
-
-int __ufifo_bsem_wait(sem_t *bsem, ufifo_t *handle)
-{
+    uint64_t val;
     int ret;
 
     __ufifo_data_unlock(handle);
-    ret = sem_wait(bsem);
-    __ufifo_data_lock(handle);
 
+    /* Block until eventfd becomes readable */
+    struct pollfd pfd = { .fd = efd, .events = POLLIN };
+    ret = poll(&pfd, 1, -1); /* infinite wait */
+    if (ret > 0) {
+        if (read(efd, &val, sizeof(val)) < 0)
+            ret = -errno;
+        else
+            ret = 0;
+    } else {
+        ret = -errno;
+    }
+
+    __ufifo_data_lock(handle);
     return ret;
 }
 
-int __ufifo_bsem_timedwait(sem_t *bsem, ufifo_t *handle, long millisec)
+int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec)
 {
+    uint64_t val;
     int ret;
-    struct timespec wt;
-    struct timespec ts;
 
     __ufifo_data_unlock(handle);
 
-    wt.tv_sec = millisec / 1000;
-    wt.tv_nsec = (millisec % 1000) * 1000000;
-
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-
-    wt.tv_sec += ts.tv_sec;
-    wt.tv_nsec += ts.tv_nsec;
-    if (wt.tv_nsec >= 1000000000) {
-        wt.tv_sec += 1;
-        wt.tv_nsec %= 1000000000;
-    }
-
-    ret = sem_clockwait(bsem, CLOCK_MONOTONIC, &wt);
-    if (ret && errno == ETIMEDOUT) {
+    struct pollfd pfd = { .fd = efd, .events = POLLIN };
+    ret = poll(&pfd, 1, (int)millisec);
+    if (ret > 0) {
+        if (read(efd, &val, sizeof(val)) < 0)
+            ret = -errno;
+        else
+            ret = 0;
+    } else if (ret == 0) {
         ret = ETIMEDOUT;
+    } else {
+        ret = -errno;
     }
 
     __ufifo_data_lock(handle);
-
     return ret;
 }
 
-int __ufifo_bsem_post(sem_t *bsem)
+int __ufifo_efd_post(int efd)
 {
-    sem_trywait(bsem);
-    return sem_post(bsem);
+    uint64_t val = 1;
+    int ret = write(efd, &val, sizeof(val));
+    return ret < 0 ? -errno : 0;
+}
+
+int __ufifo_efd_drain(int efd)
+{
+    uint64_t val;
+    while (read(efd, &val, sizeof(val)) > 0) {
+    }
+    return 0;
 }

--- a/src/ufifo_sync.c
+++ b/src/ufifo_sync.c
@@ -5,8 +5,9 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <sys/eventfd.h>
-
 #include <unistd.h>
+
+#include "utils.h"
 
 int __ufifo_ctrl_lock(ufifo_t *handle)
 {
@@ -123,11 +124,12 @@ int __ufifo_efd_create(void)
     return eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK | EFD_CLOEXEC);
 }
 
-int __ufifo_efd_wait(int efd, ufifo_t *handle)
+int __ufifo_efd_wait(int efd, ufifo_t *handle, int *waiters)
 {
     uint64_t val;
     int ret;
 
+    atomic_fetch_add(waiters, 1);
     __ufifo_data_unlock(handle);
 
     /* Block until eventfd becomes readable */
@@ -143,14 +145,16 @@ int __ufifo_efd_wait(int efd, ufifo_t *handle)
     }
 
     __ufifo_data_lock(handle);
+    atomic_fetch_sub(waiters, 1);
     return ret;
 }
 
-int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec)
+int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec, int *waiters)
 {
     uint64_t val;
     int ret;
 
+    atomic_fetch_add(waiters, 1);
     __ufifo_data_unlock(handle);
 
     struct pollfd pfd = { .fd = efd, .events = POLLIN };
@@ -167,6 +171,7 @@ int __ufifo_efd_timedwait(int efd, ufifo_t *handle, long millisec)
     }
 
     __ufifo_data_lock(handle);
+    atomic_fetch_sub(waiters, 1);
     return ret;
 }
 


### PR DESCRIPTION
- Replace `sem_t` with `eventfd` for inter-process notifications to enable efficient epoll integration.
- Introduce `ufifo_broker` as a forked daemon to handle eventfd lifecycle and `SCM_RIGHTS` distribution via UNIX domain sockets.
- Remove complex UDS datagram state machine in `ufifo_epoll.c` in favor of direct eventfd usage (`efd_wr`, `efd_rd`).
- Update `ufifo_init.c`, `ufifo_opts.c`, and `ufifo_sync.c` to utilize eventfd primitives.
- Restructure `ufifo_ctrl_t` and `ufifo_sub_ctrl_t` shared memory layout to accommodate new notification design.